### PR TITLE
fix typo in Set-OneShellUserProfileCredential that was breaking the '…

### DIFF
--- a/ProfileFunctions.ps1
+++ b/ProfileFunctions.ps1
@@ -2413,7 +2413,7 @@ function Set-OneShellUserProfileCredential
                 #Only Password Specified - Update Password, Preserve Username
                 {-not $PSBoundParameters.ContainsKey('NewUsername') -and $PSBoundParameters.ContainsKey('NewPassword')}
                 {
-                    New-Object System.Management.Automation.PSCredential ($SelectedCredential.Username, $Password)
+                    New-Object System.Management.Automation.PSCredential ($SelectedCredential.Username, $NewPassword)
                 }
                 #nothing Specified except Identity - suggest preserving username, prompt to update password
                 {-not $PSBoundParameters.ContainsKey('NewUsername') -and -not $PSBoundParameters.ContainsKey('NewPassword')}


### PR DESCRIPTION
…update password only' use case